### PR TITLE
Feat/공통컴포넌트 TabBar

### DIFF
--- a/src/app/sample/core/hooks/TabBarSampleProvider.tsx
+++ b/src/app/sample/core/hooks/TabBarSampleProvider.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext, useState } from 'react';
+
+const TabBarTypeContext = createContext<{
+  tabBarType: 'tabBarType1' | 'tabBarType2';
+  setTabBarType: (v: 'tabBarType1' | 'tabBarType2') => void;
+}>({
+  tabBarType: 'tabBarType1',
+  setTabBarType: () => {},
+});
+
+export const TabBarSampleProvider = ({ children }: { children: React.ReactNode }) => {
+  const [tabBarType, setTabBarType] = useState<'tabBarType1' | 'tabBarType2'>('tabBarType1');
+  return <TabBarTypeContext.Provider value={{ tabBarType, setTabBarType }}>{children}</TabBarTypeContext.Provider>;
+};
+
+export const useTabBarType = () => {
+  return useContext(TabBarTypeContext);
+};

--- a/src/app/sample/page.tsx
+++ b/src/app/sample/page.tsx
@@ -1,12 +1,17 @@
 'use client';
-import Textarea from '@/shared/components/Input/TextArea';
-import TextFieldChat from '@/shared/components/TextFieldChat/TextFieldChat';
-import { useState } from 'react';
-import { SolidButton } from '@/shared/components/Button/SolidButton';
-import { OutlinedButton } from '@/shared/components/Button/OutlinedButton';
+
 import { colorChips } from '@/shared/styles/colorChips';
 import { Stack, SxProps } from '@mui/material';
-import Chip from '@/shared/components/Chip/Chip';
+import { Typo } from '@/shared/styles/Typo/Typo';
+import { useState } from 'react';
+
+// import Textarea from '@/shared/components/Input/TextArea';
+// import TextFieldChat from '@/shared/components/TextFieldChat/TextFieldChat';
+// import Chip from '@/shared/components/Chip/Chip';
+// import { SolidButton } from '@/shared/components/Button/SolidButton';
+// import { OutlinedButton } from '@/shared/components/Button/OutlinedButton';
+import { TabBarSampleProvider, useTabBarType } from './core/hooks/TabBarSampleProvider';
+import { TabBar } from '@/shared/components/Tab/TabBar';
 
 // Box는 div와 동일, Stack은 flex가 적용된 div입니다.
 // Typo, colorChips 아래와같이 사용하시면 됩니다.
@@ -14,13 +19,46 @@ import Chip from '@/shared/components/Chip/Chip';
 // 저는 주로 3~5개 정도 있을 땐 1번 방법을 쓰고 css가 너무 길어지면 2번처럼 변수로 정의해서 사용하는 편입니다.
 
 export default function SamplePage() {
-  const [value, setValue] = useState('');
-  const isTooShort = value.length > 0 && value.length < 10;
+  return (
+    <TabBarSampleProvider>
+      <TabBarSample />
+    </TabBarSampleProvider>
+  );
+}
+
+function TabBarSample() {
+  // const [value, setValue] = useState('');
+  // const isTooShort = value.length > 0 && value.length < 10;
+
+  // XXX:탭바 사용할 페이지 레이아웃에 프로바이더를 넣고, 사용할 컴포넌트에서 탭바를 추가합니다!
+  const { tabBarType, setTabBarType } = useTabBarType();
 
   return (
     <Stack justifyContent="center" alignItems="center" gap="20px" padding="20px" height="100%">
+      <Stack
+        direction="column"
+        width="100%"
+        height="100%"
+        alignItems="flex-start"
+        bgcolor={colorChips.background.f7f7f7}
+      >
+        {/* 헤더 영역- 탭바*/}
+        <Stack width="100%" borderBottom={`1px solid ${colorChips.black[100]}`}>
+          <TabBar
+            currentVal={tabBarType}
+            firstVal={'tabBarType1'}
+            firstLabel="테스트1"
+            secondVal={'tabBarType2'}
+            secondLabel="테스트2"
+            handleChange={(val) => setTabBarType(val as 'tabBarType1' | 'tabBarType2')}
+          />
+        </Stack>
+        {/* 탭바 타입에 따른 컴포넌트 사용 영역 */}
+        {tabBarType === 'tabBarType1' ? <TabBarTest1 /> : <TabBarTest2 />}
+      </Stack>
+
       {/* CommonButton 테스트 - 확인하고 다 주석처리해주셔도 됩니다~ */}
-      <SolidButton buttonSize="sm" text="sm with icon" hasIcon={true} />
+      {/* <SolidButton buttonSize="sm" text="sm with icon" hasIcon={true} />
       <SolidButton buttonSize="sm" text="sm no icon" />
       <SolidButton buttonSize="sm" text="sm disabled" disabled={true} />
       <SolidButton text="md with icon" hasIcon={true} />
@@ -32,10 +70,10 @@ export default function SamplePage() {
       <OutlinedButton buttonSize="sm" text="sm outlined disabled" disabled={true} justifyContent="flex-start" />
       <OutlinedButton text="md outlined default" />
       <OutlinedButton buttonType="done" text="md outlined done" hasIcon={true} />
-      <OutlinedButton text="md outlined disabled" disabled={true} />
+      <OutlinedButton text="md outlined disabled" disabled={true} /> */}
 
       {/* TextFieldChat, Textarea 테스트 - 확인하고 주석 처리하셔도 됩니다!?! */}
-      <Stack height="300px" gap="20px" bgcolor={colorChips.background.f7f7f7}>
+      {/* <Stack height="300px" gap="20px" bgcolor={colorChips.background.f7f7f7}>
         <TextFieldChat
           type="user"
           message="테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트"
@@ -57,27 +95,37 @@ export default function SamplePage() {
         <Chip type="region" />
         <Chip type="select" />
         <Chip type="small">맞춤 이사</Chip>
-      </Stack>
+      </Stack> */}
     </Stack>
   );
 }
 
-// 스타일링 방법 2.
-const typoWraperSx: SxProps = {
-  direction: 'row',
-  justifyContent: 'center',
-  alignItems: 'center',
-  padding: '12px',
-  bgcolor: colorChips.secondary.red[200],
-  borderRadius: '20px',
+const TabBarTest1 = () => {
+  return (
+    <Stack
+      direction="row"
+      width="100%"
+      height="100px"
+      justifyContent="center"
+      alignItems="center"
+      bgcolor={colorChips.primary[100]}
+    >
+      <Typo content="탭바테스트 1번컴포넌트입니다." className="text_M_16" color={colorChips.black[400]} />
+    </Stack>
+  );
 };
 
-const buttonSx: SxProps = {
-  height: '50px',
-  borderRadius: '20px',
-
-  // 이렇게 추가로 스타일 커스텀 가능합니다
-  '&:hover': {
-    bgcolor: colorChips.secondary.red[100],
-  },
+const TabBarTest2 = () => {
+  return (
+    <Stack
+      direction="row"
+      width="100%"
+      height="100px"
+      justifyContent="center"
+      alignItems="center"
+      bgcolor={colorChips.secondary.yellow[100]}
+    >
+      <Typo content="탭바테스트 2번컴포넌트입니다." className="text_M_16" color={colorChips.black[400]} />
+    </Stack>
+  );
 };

--- a/src/shared/components/Tab/TabBar.tsx
+++ b/src/shared/components/Tab/TabBar.tsx
@@ -30,6 +30,7 @@ const StyledTabs = styled(Tabs)`
   }
 `;
 const StyledTab = styled(Tab)`
+  height: 54px;
   font-family: 'pretendard';
   font-size: '14px';
   font-style: 'normal';

--- a/src/shared/components/Tab/TabBar.tsx
+++ b/src/shared/components/Tab/TabBar.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { colorChips } from '@/shared/styles/colorChips';
+import styled from '@emotion/styled';
+import { Tab, Tabs } from '@mui/material';
+import React from 'react';
+
+interface TabsProps {
+  currentVal: string; // 현재 탭 고유 id
+  firstVal: string; // 탭 고유 id
+  firstLabel: string; // 탭 라벨
+  secondVal: string;
+  secondLabel: string;
+  handleChange: (val: string) => void;
+}
+
+export const TabBar = ({ currentVal, firstVal, firstLabel, secondVal, secondLabel, handleChange }: TabsProps) => {
+  return (
+    <StyledTabs value={currentVal} onChange={(_, val) => handleChange(val)} variant="standard">
+      <StyledTab value={firstVal} label={firstLabel}></StyledTab>
+      <StyledTab value={secondVal} label={secondLabel}></StyledTab>
+    </StyledTabs>
+  );
+};
+
+const StyledTabs = styled(Tabs)`
+  width: fit-content;
+  & .MuiTabs-indicator {
+    background-color: transparent;
+  }
+`;
+const StyledTab = styled(Tab)`
+  font-family: 'pretendard';
+  font-size: '14px';
+  font-style: 'normal';
+  font-weight: 700;
+  line-height: '24px';
+  color: ${colorChips.grayScale[400]};
+  border-bottom: 2px solid transparent;
+
+  &.Mui-selected {
+    color: #2b2b2b;
+    border-bottom: 2px solid ${colorChips.black[400]};
+  }
+`;


### PR DESCRIPTION
## 🌟 작업 내용 요약(500자 이내)
- 공통컴포넌트 TabBar 구현. 피그마 컴포넌트 쪽에 있는 Tab-Button 은 사용하는 페이지가 없는거같아서 일단 기본 Tab컴포넌트만 제작했습니다. 혹시 페이지 제작중 탭버튼 컴포넌트가 필요하면 말씀해주세요!!
  
## 📢 팀원들에게 공유 사항
- 샘플 폴더 `TabBarSampleProvider` 코드 참고해서, 사용할 페이지에서 필요한 탭타입 프로바이더 추가하여 사용하시면 됩니다.

## 📷 스크린샷

![스크린샷 2025-05-20 114128](https://github.com/user-attachments/assets/e6bbc2b3-24bd-4a6f-b77c-0e020c025b75)
![스크린샷 2025-05-20 114149](https://github.com/user-attachments/assets/678e5a32-65a5-4471-8e15-144b6811c444)
