### PR TITLE
feat/ToastPopup 컴포넌트

### DIFF
--- a/public/assets/images/info-icon/info-16x16-blue.svg
+++ b/public/assets/images/info-icon/info-16x16-blue.svg
@@ -1,0 +1,12 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1_8573)">
+<circle cx="8" cy="8" r="7.5" fill="#F5FAFF" stroke="#4DA9FF"/>
+<rect x="7" y="4" width="2" height="6" fill="#4DA9FF"/>
+<circle cx="8" cy="12" r="1" fill="#4DA9FF"/>
+</g>
+<defs>
+<clipPath id="clip0_1_8573">
+<rect width="16" height="16" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/public/assets/images/info-icon/info-24x24-blue.svg
+++ b/public/assets/images/info-icon/info-24x24-blue.svg
@@ -1,0 +1,12 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1_8570)">
+<circle cx="12" cy="12" r="11.5" fill="#F5FAFF" stroke="#4DA9FF"/>
+<rect x="11" y="6" width="2" height="8" fill="#4DA9FF"/>
+<circle cx="12" cy="17" r="1" fill="#4DA9FF"/>
+</g>
+<defs>
+<clipPath id="clip0_1_8570">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/app/sample/page.tsx
+++ b/src/app/sample/page.tsx
@@ -3,7 +3,7 @@
 import { colorChips } from '@/shared/styles/colorChips';
 import { Stack, SxProps } from '@mui/material';
 import { Typo } from '@/shared/styles/Typo/Typo';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 // import Textarea from '@/shared/components/Input/TextArea';
 // import TextFieldChat from '@/shared/components/TextFieldChat/TextFieldChat';
@@ -12,6 +12,7 @@ import { useState } from 'react';
 // import { OutlinedButton } from '@/shared/components/Button/OutlinedButton';
 import { TabBarSampleProvider, useTabBarType } from './core/hooks/TabBarSampleProvider';
 import { TabBar } from '@/shared/components/Tab/TabBar';
+import { ToastPopup } from '@/shared/components/Popup/ToastPopup';
 
 // Box는 div와 동일, Stack은 flex가 적용된 div입니다.
 // Typo, colorChips 아래와같이 사용하시면 됩니다.
@@ -101,16 +102,23 @@ function TabBarSample() {
 }
 
 const TabBarTest1 = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  useEffect(() => {
+    setIsOpen(true);
+  }, []);
   return (
     <Stack
-      direction="row"
+      direction="column"
       width="100%"
-      height="100px"
-      justifyContent="center"
+      height="300px"
+      justifyContent="flex-start"
       alignItems="center"
-      bgcolor={colorChips.primary[100]}
+      padding="20px"
+      gap="20px"
+      bgcolor={colorChips.background.f7f7f7}
     >
       <Typo content="탭바테스트 1번컴포넌트입니다." className="text_M_16" color={colorChips.black[400]} />
+      <ToastPopup isOpen={isOpen} onClose={() => setIsOpen(false)} message="테스트 테스트 테스트" />
     </Stack>
   );
 };

--- a/src/shared/components/Popup/ToastPopup.tsx
+++ b/src/shared/components/Popup/ToastPopup.tsx
@@ -1,0 +1,61 @@
+import { colorChips } from '@/shared/styles/colorChips';
+import { Typo } from '@/shared/styles/Typo/Typo';
+import { Stack } from '@mui/material';
+import Image from 'next/image';
+import { useMediaQuery } from '@mui/material';
+import { useEffect, useState } from 'react';
+
+interface ToastPopupProps {
+  isOpen: boolean;
+  onClose: () => void;
+  message: string;
+}
+
+export const ToastPopup = ({ isOpen, onClose, message }: ToastPopupProps) => {
+  const isDesktop = useMediaQuery('(min-width: 744px)');
+  const toastIcon = isDesktop
+    ? './assets/images/info-icon/info-24x24-blue.svg'
+    : './assets/images/info-icon/info-16x16-blue.svg';
+  const toastIconSize = isDesktop ? 24 : 16;
+  const toastMsgSize = isDesktop ? 'text_SB_16' : 'text_SB_13';
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setShow(true);
+      const timer = setTimeout(() => {
+        setShow(false);
+        setTimeout(onClose, 300); // 애니메이션 완료 후 onClose 호출
+      }, 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen, onClose]);
+
+  if (!isOpen && !show) return null;
+
+  return (
+    <Stack
+      sx={{
+        ...toastSx,
+        opacity: show ? 1 : 0,
+        transition: 'opacity 0.3s ease-in-out',
+        position: 'relative',
+        marginTop: '16px',
+      }}
+    >
+      <Image src={toastIcon} alt="toast" width={toastIconSize} height={toastIconSize} />
+      <Typo className={toastMsgSize} content={message} color={colorChips.primary[300]} />
+    </Stack>
+  );
+};
+
+const toastSx = {
+  width: '100%',
+  backgroundColor: colorChips.primary[100],
+  border: `1px solid ${colorChips.primary[200]}`,
+  borderRadius: '12px',
+  gap: { xs: '8px', md: '16px' },
+  padding: { xs: '10px 24px', md: '24px 32px' },
+  flexDirection: 'row',
+  alignItems: 'center',
+};


### PR DESCRIPTION
## 🌟 작업 내용 요약(500자 이내)
- 토스트팝업 컴포넌트 구현
  
## 📢 팀원들에게 공유 사항
- 원래 색상이나 아이콘타입 등 확장 가능한 컴포넌트를 만드려다가, 
해당 디자인으로 한 페이지에서만 쓰이는거같아서 일단 색상, 아이콘 고정으로 만들었습니다.
이후에 토스트메시지가 추가된다고 하면 커스텀 가능하게 다시 수정해볼게요.

## 📷 스크린샷
- 태블릿 사이즈
![스크린샷 2025-05-20 142240](https://github.com/user-attachments/assets/675e4f3d-f417-4a73-8310-407c03dd8d12)
- 데스크탑 사이즈
![스크린샷 2025-05-20 142255](https://github.com/user-attachments/assets/07ac2231-82f8-4859-a1d0-b2a224194c20)

