### PR TITLE
Feat/공통컴포넌트 Modal

### DIFF
--- a/src/app/sample/page.tsx
+++ b/src/app/sample/page.tsx
@@ -8,10 +8,11 @@ import { useState } from 'react';
 // import Textarea from '@/shared/components/Input/TextArea';
 // import TextFieldChat from '@/shared/components/TextFieldChat/TextFieldChat';
 // import Chip from '@/shared/components/Chip/Chip';
-// import { SolidButton } from '@/shared/components/Button/SolidButton';
-// import { OutlinedButton } from '@/shared/components/Button/OutlinedButton';
 import { TabBarSampleProvider, useTabBarType } from './core/hooks/TabBarSampleProvider';
 import { TabBar } from '@/shared/components/Tab/TabBar';
+import { CommonModal } from '@/shared/components/Modal/CommonModal';
+import { SolidButton } from '@/shared/components/Button/SolidButton';
+import { OutlinedButton } from '@/shared/components/Button/OutlinedButton';
 
 // Box는 div와 동일, Stack은 flex가 적용된 div입니다.
 // Typo, colorChips 아래와같이 사용하시면 됩니다.
@@ -116,16 +117,37 @@ const TabBarTest1 = () => {
 };
 
 const TabBarTest2 = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const handleOpenModal = () => {
+    setIsModalOpen(true);
+  };
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
+
   return (
-    <Stack
-      direction="row"
-      width="100%"
-      height="100px"
-      justifyContent="center"
-      alignItems="center"
-      bgcolor={colorChips.secondary.yellow[100]}
-    >
-      <Typo content="탭바테스트 2번컴포넌트입니다." className="text_M_16" color={colorChips.black[400]} />
-    </Stack>
+    <>
+      <Stack
+        direction="column"
+        width="100%"
+        height="300px"
+        justifyContent="center"
+        alignItems="center"
+        gap="20px"
+        bgcolor={colorChips.background.f7f7f7}
+      >
+        <Typo content="탭바테스트 2번컴포넌트입니다." className="text_M_16" color={colorChips.black[400]} />
+        <OutlinedButton buttonSize="sm" text="모달열기 테스트" onClick={handleOpenModal} />
+      </Stack>
+
+      {isModalOpen && (
+        <CommonModal modalTitle="지정 견적 요청하기" isOpen={isModalOpen} handleClickClose={handleCloseModal}>
+          <Stack padding="20px 0" gap="10px" alignItems="center">
+            <Typo content="테스트테스트" className="text_M_18" color={colorChips.black[400]} />
+            <SolidButton buttonSize="sm" text="확인" onClick={handleCloseModal} />
+          </Stack>
+        </CommonModal>
+      )}
+    </>
   );
 };

--- a/src/app/sample/page.tsx
+++ b/src/app/sample/page.tsx
@@ -13,6 +13,7 @@ import { TabBar } from '@/shared/components/Tab/TabBar';
 import { CommonModal } from '@/shared/components/Modal/CommonModal';
 import { SolidButton } from '@/shared/components/Button/SolidButton';
 import { OutlinedButton } from '@/shared/components/Button/OutlinedButton';
+import { ResponsiveModal } from '@/shared/components/Modal/ResponsiveModal';
 
 // Box는 div와 동일, Stack은 flex가 적용된 div입니다.
 // Typo, colorChips 아래와같이 사용하시면 됩니다.
@@ -117,12 +118,19 @@ const TabBarTest1 = () => {
 };
 
 const TabBarTest2 = () => {
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const handleOpenModal = () => {
-    setIsModalOpen(true);
+  const [isCommonModalOpen, setIsCommonModalOpen] = useState(false);
+  const [isResponsiveModalOpen, setIsResponsiveModalOpen] = useState(false);
+  const handleOpenCommonModal = () => {
+    setIsCommonModalOpen(true);
   };
-  const handleCloseModal = () => {
-    setIsModalOpen(false);
+  const handleCloseCommonModal = () => {
+    setIsCommonModalOpen(false);
+  };
+  const handleOpenResponsiveModal = () => {
+    setIsResponsiveModalOpen(true);
+  };
+  const handleCloseResponsiveModal = () => {
+    setIsResponsiveModalOpen(false);
   };
 
   return (
@@ -137,16 +145,33 @@ const TabBarTest2 = () => {
         bgcolor={colorChips.background.f7f7f7}
       >
         <Typo content="탭바테스트 2번컴포넌트입니다." className="text_M_16" color={colorChips.black[400]} />
-        <OutlinedButton buttonSize="sm" text="모달열기 테스트" onClick={handleOpenModal} />
+        <OutlinedButton buttonSize="sm" text="CommonModal 열기" onClick={handleOpenCommonModal} />
+        <OutlinedButton buttonSize="sm" text="ResponsiveModal 열기" onClick={handleOpenResponsiveModal} />
       </Stack>
 
-      {isModalOpen && (
-        <CommonModal modalTitle="지정 견적 요청하기" isOpen={isModalOpen} handleClickClose={handleCloseModal}>
+      {isCommonModalOpen && (
+        <CommonModal
+          modalTitle="지정 견적 요청하기"
+          isOpen={isCommonModalOpen}
+          handleClickClose={handleCloseCommonModal}
+        >
           <Stack padding="20px 0" gap="10px" alignItems="center">
             <Typo content="테스트테스트" className="text_M_18" color={colorChips.black[400]} />
-            <SolidButton buttonSize="sm" text="확인" onClick={handleCloseModal} />
+            <SolidButton buttonSize="sm" text="확인" onClick={handleCloseCommonModal} />
           </Stack>
         </CommonModal>
+      )}
+
+      {isResponsiveModalOpen && (
+        <ResponsiveModal
+          modalTitle="견적 보내기"
+          isOpen={isResponsiveModalOpen}
+          handleClickClose={handleCloseResponsiveModal}
+        >
+          <Stack padding="20px 0" gap="10px" alignItems="center">
+            <Typo content="테스트테스트" className="text_M_18" color={colorChips.black[400]} />
+          </Stack>
+        </ResponsiveModal>
       )}
     </>
   );

--- a/src/shared/components/Modal/CommonModal.tsx
+++ b/src/shared/components/Modal/CommonModal.tsx
@@ -1,0 +1,88 @@
+import { Modal, Stack, SxProps, useMediaQuery } from '@mui/material';
+import { Typo } from '@/shared/styles/Typo/Typo';
+import { colorChips } from '@/shared/styles/colorChips';
+import Image from 'next/image';
+
+interface CommonModalProps {
+  modalTitle: string;
+  isOpen: boolean;
+  handleClickClose: () => void;
+  children: React.ReactNode;
+}
+
+export const CommonModal: React.FC<CommonModalProps> = ({ modalTitle, isOpen, handleClickClose, children }) => {
+  const isDesktop = useMediaQuery('(min-width: 744px)');
+  const closeIconSrc = isDesktop ? '/assets/images/x-icon/x-36x36.svg' : '/assets/images/x-icon/x-24x24.svg';
+  const closeIconSize = isDesktop ? 36 : 24;
+
+  return (
+    <Modal
+      open={isOpen}
+      onClose={handleClickClose}
+      aria-labelledby="common-modal"
+      sx={{
+        zIndex: 10000,
+        marginX: '20px',
+        '& .MuiBackdrop-root': {
+          backgroundColor: 'rgba(0, 0, 0, 0.6)',
+        },
+        '& :focus': {
+          outline: 'none',
+        },
+      }}
+    >
+      <Stack sx={CommonModalSx}>
+        <Stack sx={ModalWrapperSx}>
+          <Stack sx={ModalHeaderWrapperSx}>
+            <Typo className="modal_header" content={modalTitle} color={colorChips.black[400]} />
+            <Image
+              src={closeIconSrc}
+              alt="close"
+              width={closeIconSize}
+              height={closeIconSize}
+              onClick={handleClickClose}
+              style={{ cursor: 'pointer' }}
+            />
+          </Stack>
+
+          {children}
+        </Stack>
+      </Stack>
+    </Modal>
+  );
+};
+
+const CommonModalSx: SxProps = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: '80%', // TODO:여기 뷰보고 다시 잡기
+  minWidth: '292px',
+  maxWidth: '608px',
+  height: 'auto',
+  backgroundColor: colorChips.grayScale[50],
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: { xs: '24px', md: '32px' },
+  padding: { xs: '24px 16px', md: '32px 24px 40px' },
+  boxSizing: 'border-box',
+} as const;
+
+const ModalWrapperSx: SxProps = {
+  width: '100%',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+} as const;
+
+const ModalHeaderWrapperSx: SxProps = {
+  width: '100%',
+  height: 'fit-content',
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: '8px',
+} as const;

--- a/src/shared/components/Modal/ResponsiveModal.tsx
+++ b/src/shared/components/Modal/ResponsiveModal.tsx
@@ -3,14 +3,14 @@ import { Typo } from '@/shared/styles/Typo/Typo';
 import { colorChips } from '@/shared/styles/colorChips';
 import Image from 'next/image';
 
-interface CommonModalProps {
+interface ResponsiveModalProps {
   modalTitle: string;
   isOpen: boolean;
   handleClickClose: () => void;
   children: React.ReactNode;
 }
 
-export const CommonModal: React.FC<CommonModalProps> = ({ modalTitle, isOpen, handleClickClose, children }) => {
+export const ResponsiveModal: React.FC<ResponsiveModalProps> = ({ modalTitle, isOpen, handleClickClose, children }) => {
   const theme = useTheme();
   const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
   const closeIconSrc = isDesktop ? '/assets/images/x-icon/x-36x36.svg' : '/assets/images/x-icon/x-24x24.svg';
@@ -23,7 +23,7 @@ export const CommonModal: React.FC<CommonModalProps> = ({ modalTitle, isOpen, ha
       aria-labelledby="common-modal"
       sx={{
         zIndex: 10000,
-        marginX: '20px',
+        marginX: { xs: '0px', sm: '20px' },
         '& .MuiBackdrop-root': {
           backgroundColor: 'rgba(0, 0, 0, 0.6)',
         },
@@ -55,20 +55,21 @@ export const CommonModal: React.FC<CommonModalProps> = ({ modalTitle, isOpen, ha
 
 const CommonModalSx: SxProps = {
   position: 'absolute',
-  top: '50%',
+  top: { xs: 'auto', sm: '50%' },
+  bottom: { xs: 0, sm: 'auto' },
   left: '50%',
-  transform: 'translate(-50%, -50%)',
-  width: '80%',
-  minWidth: '292px',
-  maxWidth: '608px',
-  height: 'auto',
+  transform: { xs: 'translateX(-50%)', sm: 'translate(-50%, -50%)' },
+  width: { xs: '100%', sm: '80%' },
+  minWidth: { xs: '100%', sm: '292px' },
+  maxWidth: { xs: '100%', sm: '608px' },
+  height: { xs: '90%', sm: 'auto' },
   backgroundColor: colorChips.grayScale[50],
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
   justifyContent: 'center',
-  borderRadius: { xs: '24px', md: '32px' },
-  padding: { xs: '24px 16px', md: '32px 24px 40px' },
+  borderRadius: { xs: '32px 32px 0px 0px', sm: '32px' },
+  padding: '32px 24px 40px',
   boxSizing: 'border-box',
 } as const;
 

--- a/src/shared/components/Popup/ToastPopup.tsx
+++ b/src/shared/components/Popup/ToastPopup.tsx
@@ -1,0 +1,62 @@
+import { colorChips } from '@/shared/styles/colorChips';
+import { Typo } from '@/shared/styles/Typo/Typo';
+import { Stack, useTheme } from '@mui/material';
+import Image from 'next/image';
+import { useMediaQuery } from '@mui/material';
+import { useEffect, useState } from 'react';
+
+interface ToastPopupProps {
+  isOpen: boolean;
+  onClose: () => void;
+  message: string;
+}
+
+export const ToastPopup = ({ isOpen, onClose, message }: ToastPopupProps) => {
+  const theme = useTheme();
+  const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
+  const toastIcon = isDesktop
+    ? './assets/images/info-icon/info-24x24-blue.svg'
+    : './assets/images/info-icon/info-16x16-blue.svg';
+  const toastIconSize = isDesktop ? 24 : 16;
+  const toastMsgSize = isDesktop ? 'text_SB_16' : 'text_SB_13';
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setShow(true);
+      const timer = setTimeout(() => {
+        setShow(false);
+        setTimeout(onClose, 300); // 애니메이션 완료 후 onClose 호출
+      }, 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen, onClose]);
+
+  if (!isOpen && !show) return null;
+
+  return (
+    <Stack
+      sx={{
+        ...toastSx,
+        opacity: show ? 1 : 0,
+        transition: 'opacity 0.3s ease-in-out',
+        position: 'relative',
+        marginTop: '16px',
+      }}
+    >
+      <Image src={toastIcon} alt="toast" width={toastIconSize} height={toastIconSize} />
+      <Typo className={toastMsgSize} content={message} color={colorChips.primary[300]} />
+    </Stack>
+  );
+};
+
+const toastSx = {
+  width: '100%',
+  backgroundColor: colorChips.primary[100],
+  border: `1px solid ${colorChips.primary[200]}`,
+  borderRadius: '12px',
+  gap: { xs: '8px', md: '16px' },
+  padding: { xs: '10px 24px', md: '24px 32px' },
+  flexDirection: 'row',
+  alignItems: 'center',
+};

--- a/src/shared/styles/Typo/Typo.tsx
+++ b/src/shared/styles/Typo/Typo.tsx
@@ -28,7 +28,8 @@ export type TypoClassName =
   | 'text_M_13'
   | 'text_SB_12'
   | 'text_M_12'
-  | 'text_R_12';
+  | 'text_R_12'
+  | 'modal_header';
 
 interface CreateTypographyComponent extends TypographyProps {
   className: TypoClassName;

--- a/src/shared/styles/Typo/TypoStyles.tsx
+++ b/src/shared/styles/Typo/TypoStyles.tsx
@@ -197,4 +197,15 @@ export const typographyStyles: TypoStyles = {
     fontWeight: 400,
     lineHeight: '18px',
   },
+  modal_header: {
+    fontFamily: 'pretendard',
+    fontSize: '24px',
+    fontStyle: 'normal',
+    fontWeight: 600,
+    lineHeight: '32px',
+    '@media (max-width: 744px)': {
+      fontSize: '18px',
+      lineHeight: '26px',
+    },
+  },
 };

--- a/src/shared/theme.ts
+++ b/src/shared/theme.ts
@@ -18,7 +18,7 @@ const theme = createTheme({
   breakpoints: {
     values: {
       xs: 0,
-      sm: 360,
+      sm: 375,
       md: 744,
       lg: 1200,
       xl: 1500,

--- a/src/shared/theme.ts
+++ b/src/shared/theme.ts
@@ -17,11 +17,11 @@ const theme = createTheme({
   },
   breakpoints: {
     values: {
-      xs: 0, // mobile
-      sm: 744, // tablet
-      md: 1200, // desktop
-      lg: 1500,
-      xl: 1536,
+      xs: 0,
+      sm: 360,
+      md: 744,
+      lg: 1200,
+      xl: 1500,
     },
   },
 });


### PR DESCRIPTION
## 🌟 작업 내용 요약(500자 이내)
- CommonModal : 일반적인 모달
- ReponsiveModal : 모바일에서 바텀에 고정되는 반응형 모달
  
## 📢 팀원들에게 공유 사항
- CommonModal, ResponsiveModal 모두 타이틀부분 텍스트가 반응형으로 사이즈 달라져서 typo class 추가했습니다.
- "프롭으로 받은 타이틀텍스트와 닫기 버튼"까지만 기본으로 가지고 있는 아주 기본 모달입니다. **모달 안에 들어가는 내용 별도 컴포넌트로 제작하여 children으로 전달하면 됩니다!**
- 희성님 말씀해주신대로 theme에서 breakpoint 가장작은거 375로 수정했는데, 이번에 반응형 모달 모바일 뷰를 보려면 생각보다 많이 줄여야되더라고요. 보통 폰도 요즘 375를 넘기는데 기준 다시 잡으면 좋을거같아요. 테스트화면 보시고 다시 이야기해봐요!

## 📷 스크린샷
- CommonModal 피그마 해당 디자인
![스크린샷 2025-05-20 152404](https://github.com/user-attachments/assets/85d03b48-2115-4e5d-8858-3ec7cb4ae627)
![스크린샷 2025-05-20 152353](https://github.com/user-attachments/assets/616a46b4-d206-453d-9de5-fd61bc0a3d24)

- CommonModal 테스트 화면
![스크린샷 2025-05-20 152307](https://github.com/user-attachments/assets/745c8041-5d16-45e6-8ca2-3f3e71e0e196)
![스크린샷 2025-05-20 152328](https://github.com/user-attachments/assets/22e4b4fa-acdf-45e4-bcc9-2b61e11ec3ed)

- ResponsiveModal 피그마 해당 디자인
![스크린샷 2025-05-20 155502](https://github.com/user-attachments/assets/b78dac45-9830-4bd6-b4d5-4660e9fdbd47)

- ResponsiveModal 테스트화면
![스크린샷 2025-05-20 155119](https://github.com/user-attachments/assets/319d9f0a-243d-4bb4-ae3e-d0f9b62cf4cf)
![스크린샷 2025-05-20 155155](https://github.com/user-attachments/assets/e1a14deb-368a-4730-b39c-a8a57ff5a26b)
