### PR TITLE
feat: Pagination 공통컴포넌트

### DIFF
--- a/src/app/sample/page.tsx
+++ b/src/app/sample/page.tsx
@@ -17,6 +17,7 @@ import { OutlinedButton } from '@/shared/components/Button/OutlinedButton';
 import { ResponsiveModal } from '@/shared/components/Modal/ResponsiveModal';
 import DropDown from '@/shared/components/DropDown/DropDown';
 import FilterCheckList from '@/shared/components/DropDown/FilterCheckList';
+import { CommonPagination } from '@/shared/components/Pagination/CommonPagination';
 
 // Box는 div와 동일, Stack은 flex가 적용된 div입니다.
 // Typo, colorChips 아래와같이 사용하시면 됩니다.
@@ -106,6 +107,7 @@ function TabBarSample() {
 }
 
 const TabBarTest1 = () => {
+  const [pageNum, setPageNum] = useState(1);
   const [isOpen, setIsOpen] = useState(false);
   const [selectedRegion, setSelectedRegion] = useState('지역');
   const [selectedService, setSelectedService] = useState('서비스');
@@ -134,11 +136,11 @@ const TabBarTest1 = () => {
       height="300px"
       justifyContent="flex-start"
       alignItems="center"
-      padding="20px"
       gap="20px"
       bgcolor={colorChips.background.f7f7f7}
     >
       <Typo content="탭바테스트 1번컴포넌트입니다." className="text_M_16" color={colorChips.black[400]} />
+      <CommonPagination page={pageNum} totalCount={10} handleChange={(event, value) => setPageNum(value)} />
       {/* 팝업 */}
       {/* <ToastPopup isOpen={isOpen} onClose={() => setIsOpen(false)} message="테스트 테스트 테스트" /> */}
       {/* 드롭다운 */}

--- a/src/shared/components/Pagination/CommonPagination.tsx
+++ b/src/shared/components/Pagination/CommonPagination.tsx
@@ -1,0 +1,54 @@
+import { Pagination } from '@mui/material';
+import { colorChips } from '@/shared/styles/colorChips';
+
+interface CustomPaginationProps {
+  page: number; // 현재 페이지
+  totalCount: number; // 전체 페이지 수
+  handleChange: (event: React.ChangeEvent<unknown>, value: number) => void;
+}
+/*
+ex)
+  const handleChange = (event: React.ChangeEvent<unknown>, value: number) => {
+   setPage(value);
+  };
+ */
+export const CommonPagination: React.FC<CustomPaginationProps> = ({ page, totalCount, handleChange }) => {
+  return (
+    <Pagination
+      defaultPage={1}
+      page={page}
+      count={totalCount}
+      onChange={handleChange}
+      siblingCount={1}
+      boundaryCount={1}
+      variant="text"
+      shape="rounded"
+      sx={{
+        '& .MuiPaginationItem-root': {
+          width: { xs: '30px', sm: '34px', md: '48px' },
+          height: { xs: '30px', sm: '34px', md: '48px' },
+          borderRadius: { xs: '6px', md: '8px' },
+          fontFamily: 'pretendard',
+          fontSize: { xs: '14px', sm: '16px', md: '18px' },
+          lineHeight: { xs: '24px', sm: '28px', md: '40px' },
+          marginRight: '4px', // 숫자 버튼 간격
+          backgroundColor: colorChips.grayScale[50], // 버튼 배경색
+          color: colorChips.grayScale[300], // 버튼의 텍스트 색상
+          fontWeight: '400',
+          '&.Mui-selected': {
+            backgroundColor: colorChips.grayScale[50], // 선택된 버튼 배경색
+            color: colorChips.black[400], // 선택된 버튼의 텍스트 색상
+            fontWeight: '600',
+          },
+        },
+        '& .MuiPaginationItem-root:last-of-type': {
+          marginRight: 0, // 마지막 숫자 버튼 간격 0
+        },
+        '& .MuiPaginationItem-previousNext': {
+          marginRight: { xs: '6px', sm: '8px', md: '10px' },
+          color: colorChips.black[400], // 활성화 색상
+        },
+      }}
+    />
+  );
+};


### PR DESCRIPTION
## 🌟 작업 내용 요약(500자 이내)
- 페이지네이션 공통컴포넌트 추가. 샘플페이지에서 확인 가능
  
## 📢 팀원들에게 공유 사항
- 피그마 디자인대로 모바일에서는 페이지버튼이 5개만 보이도록 최대한 맞추고 싶었으나.. 중간 페이지를 누르면 디자인이 영 이상해서
데스크탑과 동일하게 7개를 보여주고 사이즈만 줄였습니다.


## 📷 스크린샷
- 데스크탑
![스크린샷 2025-05-22 134400](https://github.com/user-attachments/assets/dcc3b4b9-f5d2-46ba-8fc4-262015a93e41)
- 모바일
![스크린샷 2025-05-22 134412](https://github.com/user-attachments/assets/ea7edff4-236e-4553-b62a-b13440352606)

