### PR TITLE
[ADD] : Searchbar, OAuth Roading Page 

### DIFF
--- a/src/app/(auth)/OAuth/callback/page.tsx
+++ b/src/app/(auth)/OAuth/callback/page.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { colorChips } from '@/shared/styles/colorChips';
+import { Typo } from '@/shared/styles/Typo/Typo';
+import { CircularProgress } from '@mui/material';
+import { Box, Stack } from '@mui/system';
+import { keyframes } from '@emotion/react';
+
+const blink = keyframes`
+  0%   { opacity: 0; }
+  33%  { opacity: 1; }
+  66%  { opacity: 0; }
+  100% { opacity: 0; }
+`;
+
+export default function OAuthCallbackPage() {
+  return (
+    <Stack width="100vw" height="100vh" justifyContent="center" alignItems="center" gap="16px">
+      <CircularProgress size={64} thickness={5} />
+      <Typo className="text_M_20" color={colorChips.grayScale[300]}>
+        로그인 중 입니다
+        <Box
+          component="span"
+          sx={{
+            animation: `${blink} 1.4s infinite`,
+            animationDelay: '0s',
+            display: 'inline-block',
+            ml: '4px',
+          }}
+        >
+          .
+        </Box>
+        <Box
+          component="span"
+          sx={{
+            animation: `${blink} 1.4s infinite`,
+            animationDelay: '0.2s',
+            display: 'inline-block',
+            ml: '4px',
+          }}
+        >
+          .
+        </Box>
+        <Box
+          component="span"
+          sx={{
+            animation: `${blink} 1.4s infinite`,
+            animationDelay: '0.4s',
+            display: 'inline-block',
+            ml: '4px',
+          }}
+        >
+          .
+        </Box>
+      </Typo>
+    </Stack>
+  );
+}

--- a/src/app/sample/page.tsx
+++ b/src/app/sample/page.tsx
@@ -24,6 +24,7 @@ import Card, { UserData } from '@/shared/components/Card/Card';
 import { UserCardData } from '@/shared/components/Card/CardPresets';
 import DatePicker from '@/shared/components/DatePicker/DatePicker';
 import { Dayjs } from 'dayjs';
+import SearchBar from '@/shared/components/Input/SearchBar';
 
 // Box는 div와 동일, Stack은 flex가 적용된 div입니다.
 // Typo, colorChips 아래와같이 사용하시면 됩니다.
@@ -205,7 +206,9 @@ const TabBarTest1 = () => {
       {/* <ProgressBar type="review" percentage={30} />
       </Stack> */}
       <Stack />
-      <DatePicker onSelect={handleDate} />
+      <SearchBar isModal={false} onSearch={(text) => console.log('검색:', text)} />
+      <SearchBar isModal={true} onSearch={(text) => console.log('모달 검색:', text)} />
+      {/* <DatePicker onSelect={handleDate} /> */}
     </Stack>
   );
 };

--- a/src/app/sample/page.tsx
+++ b/src/app/sample/page.tsx
@@ -206,8 +206,10 @@ const TabBarTest1 = () => {
       {/* <ProgressBar type="review" percentage={30} />
       </Stack> */}
       <Stack />
-      <SearchBar isModal={false} onSearch={(text) => console.log('검색:', text)} />
-      <SearchBar isModal={true} onSearch={(text) => console.log('모달 검색:', text)} />
+      <Stack width="600px" gap="20px">
+        <SearchBar isModal={false} onSearch={(text) => console.log('검색:', text)} />
+        <SearchBar isModal={true} onSearch={(text) => console.log('모달 검색:', text)} />
+      </Stack>
       {/* <DatePicker onSelect={handleDate} /> */}
     </Stack>
   );

--- a/src/shared/components/Input/SearchBar.tsx
+++ b/src/shared/components/Input/SearchBar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { InputAdornment, IconButton, TextField } from '@mui/material';
-import { Stack, useMediaQuery } from '@mui/system';
+import { Stack, SxProps, SystemStyleObject, Theme, useMediaQuery } from '@mui/system';
 import theme from '@/shared/theme';
 import Image from 'next/image';
 import { typographyStyles } from '@/shared/styles/Typo/TypoStyles';
@@ -22,6 +22,17 @@ export default function SearchBar({
   const [input, setInput] = useState('');
   const isMd = useMediaQuery(theme.breakpoints.down('md'));
   const iconSize = isMd ? 24 : 36;
+  const inputFont = (isMd ? typographyStyles.text_R_14 : typographyStyles.text_R_20) as SystemStyleObject<Theme>;
+
+  const inputStyle: SxProps<Theme> = {
+    '& .MuiInputBase-input': {
+      ...inputFont,
+      color: colorChips.black[400],
+    },
+    '& .MuiInputBase-input::placeholder': {
+      color: colorChips.grayScale[400],
+    },
+  };
 
   const handleClear = () => setInput('');
   const handleSearch = () => {
@@ -100,17 +111,7 @@ export default function SearchBar({
           height: 48,
         },
       }}
-      sx={{
-        '& .MuiInputBase-input': {
-          fontSize: '16px', // 텍스트 크기
-          color: colorChips.black[400],
-          padding: '12px 14px',
-        },
-        '& .MuiOutlinedInput-notchedOutline': {},
-        '& .MuiInputBase-input::placeholder': {
-          color: colorChips.grayScale[400],
-        },
-      }}
+      sx={inputStyle}
     />
   );
 }

--- a/src/shared/components/Input/SearchBar.tsx
+++ b/src/shared/components/Input/SearchBar.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useState } from 'react';
+import { InputAdornment, IconButton, TextField } from '@mui/material';
+import { Stack, useMediaQuery } from '@mui/system';
+import theme from '@/shared/theme';
+import Image from 'next/image';
+import { typographyStyles } from '@/shared/styles/Typo/TypoStyles';
+import { colorChips } from '@/shared/styles/colorChips';
+
+interface SearchBarProps {
+  isModal?: boolean;
+  placeholder?: string;
+  onSearch?: (text: string) => void;
+}
+
+export default function SearchBar({
+  isModal = false,
+  placeholder = '텍스트를 입력해 주세요.',
+  onSearch,
+}: SearchBarProps) {
+  const [input, setInput] = useState('');
+  const isMd = useMediaQuery(theme.breakpoints.down('md'));
+  const iconSize = isMd ? 24 : 36;
+
+  const handleClear = () => setInput('');
+  const handleSearch = () => {
+    if (onSearch) onSearch(input.trim());
+  };
+
+  return (
+    <TextField
+      fullWidth
+      value={input}
+      onChange={(e) => setInput(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') handleSearch();
+      }}
+      placeholder={placeholder}
+      variant="outlined"
+      InputProps={{
+        startAdornment: !isModal && (
+          <InputAdornment position="start">
+            <Image
+              src="/assets/images/input-icon/search-36x36.svg"
+              alt="검색 아이콘"
+              width={iconSize}
+              height={iconSize}
+            />
+          </InputAdornment>
+        ),
+        endAdornment: isModal && (
+          <InputAdornment position="end">
+            <Stack direction="row" gap={isMd ? '12px' : '16px'} alignItems="center">
+              {input.length >= 0 && (
+                <IconButton
+                  onClick={handleClear}
+                  size="small"
+                  sx={{
+                    p: 0,
+                    '&:hover': {
+                      backgroundColor: 'transparent',
+                    },
+                    cursor: 'pointer',
+                  }}
+                >
+                  <Image
+                    src="/assets/images/x-icon/x-circle-36x36.svg"
+                    alt="지우기 아이콘"
+                    width={iconSize}
+                    height={iconSize}
+                  />
+                </IconButton>
+              )}
+              <IconButton
+                onClick={handleSearch}
+                size="small"
+                sx={{
+                  p: 0,
+                  '&:hover': {
+                    backgroundColor: 'transparent',
+                  },
+                  cursor: 'pointer',
+                }}
+              >
+                <Image
+                  src="/assets/images/input-icon/search-36x36.svg"
+                  alt="검색 아이콘"
+                  width={iconSize}
+                  height={iconSize}
+                />
+              </IconButton>
+            </Stack>
+          </InputAdornment>
+        ),
+        sx: {
+          backgroundColor: isModal ? colorChips.background['fafafa'] : colorChips.background['f7f7f7'],
+          borderRadius: '16px',
+          p: isMd ? '14px 16px' : '14px 24px',
+          height: 48,
+        },
+      }}
+      sx={{
+        '& .MuiInputBase-input': {
+          fontSize: '16px', // 텍스트 크기
+          color: colorChips.black[400],
+          padding: '12px 14px',
+        },
+        '& .MuiOutlinedInput-notchedOutline': {},
+        '& .MuiInputBase-input::placeholder': {
+          color: colorChips.grayScale[400],
+        },
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## 🌟 작업 내용 요약(500자 이내)
- Searchbar를 추가했습니다
- OAuth 리다이렉트 후 다시 프론트로 리다이렉트 될때 띄워지는 OAuth  Roading Page 
  
## 📢 팀원들에게 공유 사항
- Searchbar는 isModal 기준으로 false면 돋보기 왼쪽 true면 오른쪽이고 아래 이미지를 참고 하시면 됩니다!
- OAuth Roading페이지 경우 잠깐 상주하기 때문에 간단하게 구현 했습니다.

## 🙋‍♂️ 리뷰어에게 요청 사항
- 더 필요하신 부분 있으시면 말씀 주세요!

## 📷 스크린샷
- Searchbar

![searchbarcode](https://github.com/user-attachments/assets/8a5c7e56-841d-4f09-bccd-35180c144329)

![searchbar](https://github.com/user-attachments/assets/700861c8-13c9-4226-96c3-caaad4e15d71)


- OAuth  Roading Page 

![랜딩 페이지](https://github.com/user-attachments/assets/fc7d42a6-396c-4bd8-94d7-b6366d77b33a)