### PR TITLE
fix: auth 디테일 수정

### DIFF
--- a/src/shared/components/Form/Auth/AuthForm.tsx
+++ b/src/shared/components/Form/Auth/AuthForm.tsx
@@ -96,9 +96,12 @@ export default function AuthForm({ mode, userType }: AuthFormProps) {
           if (!customer.isProfile) {
             router.push(PATH.customer.profile);
           } else if (!customer.hasQuotation) {
-            router.push(PATH.customer.myPage);
+            // 활성견적 x : 견적요청 페이지
+            router.push(PATH.customer.movingQuoteRequest);
+          } else {
+            // 활성견적 o : 내견적관리 페이지
+            router.push(PATH.customer.movingQuoteHistory);
           }
-          router.push(PATH.customer.movingQuoteRequest);
         }
         if (userType === 'mover') {
           const mover = res?.data?.mover;

--- a/src/shared/components/Header/core/components/HeaderProfile.tsx
+++ b/src/shared/components/Header/core/components/HeaderProfile.tsx
@@ -5,6 +5,8 @@ import { UserType } from '@/shared/types/types';
 import { Collapse, Stack } from '@mui/material';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
+import { logout } from '@/shared/core/Auth/service';
+import useUserStore from '@/shared/store/useUserStore';
 
 interface HeaderProfileProps {
   isDesktop: boolean;
@@ -25,6 +27,7 @@ export const HeaderProfile = ({
   openDropdown,
   onToggle,
 }: HeaderProfileProps) => {
+  const { logout: clearUserStore } = useUserStore();
   const router = useRouter();
   const hasProfileImg = profileImgSrc !== null;
   const imgSrc = hasProfileImg ? profileImgSrc : '/assets/images/profile-icon/login-default-36x36.svg';
@@ -34,9 +37,15 @@ export const HeaderProfile = ({
     onToggle();
     router.push(path);
   };
-  const handleClickLogout = () => {
-    // TODO: 로그아웃 로직 붙이기
-    // handleLogout();
+  // TODO: 로그아웃 api 토큰 수정되면 다시 테스트해보기
+  const handleClickLogout = async () => {
+    const res = await logout();
+    if (res.success) {
+      router.push('/'); // 로그아웃 후 랜딩페이지로 이동
+      clearUserStore(); // 유저스토어 초기화
+    } else {
+      alert('다시 시도해주세요.');
+    }
     onToggle();
   };
 

--- a/src/shared/components/Header/core/components/NavMenuDrawer.tsx
+++ b/src/shared/components/Header/core/components/NavMenuDrawer.tsx
@@ -20,6 +20,9 @@ export const NavMenuDrawer = ({ userType, isNavMenuOpen, onClose }: NavItemProps
 
   // 현재 보고있는 페이지 경로와 일치하는지 확인
   const isActiveRoute = (path: string) => {
+    if (pathname === '/') {
+      return true; // 랜딩페이지에서는 기본 black
+    }
     return pathname?.startsWith(path) || false;
   };
 

--- a/src/shared/core/Auth/service.ts
+++ b/src/shared/core/Auth/service.ts
@@ -1,5 +1,6 @@
 import customAxios from '@/lib/customAxios';
-import { LoginPayload, SignupPayload } from '@/shared/types/types';
+import { GlobalResponse, LoginPayload, SignupPayload } from '@/shared/types/types';
+import { AxiosResponse } from 'axios';
 
 export async function OAuthLogin(provider: 'google' | 'kakao' | 'naver', userType: 'customer' | 'mover') {
   const res = await customAxios.get(`/api/auth/${provider}/${userType}/login`);
@@ -16,6 +17,8 @@ export async function signup(userType: 'customer' | 'mover', payload: SignupPayl
   return res.data;
 }
 
-export async function logout(): Promise<void> {
-  await customAxios.post('/api/auth/logout');
+type LogoutResponse = GlobalResponse & AxiosResponse;
+export async function logout(): Promise<LogoutResponse> {
+  const res = await customAxios.post('/api/auth/logout');
+  return res.data;
 }

--- a/src/shared/store/useUserStore.ts
+++ b/src/shared/store/useUserStore.ts
@@ -2,21 +2,6 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { UserType } from '../types/types';
 
-// TODO: 로그인 api 완성되면 데이터타입 맞는지 확인해보기
-
-// 예시: 일반유저 로그인 성공 시 / 프로필 등록 완료 시 response data로 아래 2가지 작업을 하면 됩니다.
-// 1. setUserInfo(userType: 'customer', userInfo: {
-//     id: data.id,
-//     username: data.username,
-//     email: data.email,
-//     phoneNumber: data.phoneNumber,
-//     profileImage: data.profileImage,
-//   });
-// 2. setCustomerData(customerData: {
-//     wantService: data.wantService,
-//     livingPlace: data.livingPlace,
-//   });
-
 // 최초 로그인시 일반 유저 / 기사님 공통으로 가지는 데이터
 // - 헤더 프로필에 usernamd, profileImage 사용
 export interface UserInfo {
@@ -78,6 +63,7 @@ const useUserStore = create<UserStore>()(
         set({ moverData });
       },
       logout: () => {
+        // TODO: 여기 쿠키 지우는것도 있어야하지않나
         if (process.env.NODE_ENV === 'development') {
           localStorage.removeItem('accessToken');
           localStorage.removeItem('refreshToken');

--- a/src/shared/types/types.ts
+++ b/src/shared/types/types.ts
@@ -1,6 +1,13 @@
 export type UserType = 'customer' | 'mover' | 'temp';
 export type MovingType = 'SMALL_MOVE' | 'FAMILY_MOVE' | 'OFFICE_MOVE';
-export type QuotationStatus = 'PENDING' | 'CONFIRMED' | 'COMPLETED' | 'CANCELLED'; // TODO: 여기 확인필요
+export type QuotationStatus = 'pending' | 'confirmed' | 'completed' | 'deleted';
+
+export interface GlobalResponse {
+  success: boolean;
+  message: string;
+  data: any;
+  errorCode: string;
+}
 
 export interface LoginPayload {
   email: string;
@@ -45,6 +52,7 @@ export interface AuthResponseCustomer {
   customer: CustomerUser;
 }
 
+// 일반유저 견적 요청
 export interface CustomerRequestPayload {
   moveType: MovingType | null;
   moveDate: string;
@@ -53,7 +61,8 @@ export interface CustomerRequestPayload {
   customerId: string;
 }
 
-export interface CustomerRequestResponseData {
+// 일반유저 견적 요청 응답
+export interface CustomerRequestResponseMessage {
   id: string;
   moveType: MovingType;
   moveDate: string;
@@ -62,7 +71,7 @@ export interface CustomerRequestResponseData {
   endAddress: string;
   status: QuotationStatus;
   customerId: string;
-  assignMover: string | null; // TODO: 여기 배열로 가는지 확인필요
+  assignMover: string[] | null;
   confirmedMoverId: string | null;
   createdAt: string;
   updatedAt: string;
@@ -72,9 +81,10 @@ export interface CustomerRequestResponseData {
 export interface CustomerRequestResponse {
   success: boolean;
   message: string;
-  data: CustomerRequestResponseData;
+  data: CustomerRequestResponseMessage;
 }
 
+// 도로명주소 검색 오픈API 응답
 export interface SearchAddressResponseCommon {
   errorMessage: string;
   countPerPage: string;


### PR DESCRIPTION
## 🌟 작업 내용 요약(500자 이내)
- auth 관련 디테일 수정
- 헤더 프로필 드롭다운 - 로그아웃 api 연결(백엔드 토큰처리 방식 수정되면 다시 테스트 필요)
  
## 📢 팀원들에게 공유 사항
- `AuthForm.tsx` : 일반유저 로그인 성공 시 리다이렉트 로직 수정
  - 프로필 등록/활성견적 여부랑 상관없이 항상 견적요청페이지로 이동하고있어서 조건문 수정함
- 로그아웃 api response type 보완 -> api fail 처리 위함