### PR TITLE
fix: shareUrl 수정

### DIFF
--- a/src/app/customer/moving-quote/history/[offerId]/page.tsx
+++ b/src/app/customer/moving-quote/history/[offerId]/page.tsx
@@ -44,7 +44,7 @@ export default function Page() {
   if (!data) return null;
 
   const moverId = data.offers[0].moverId;
-  const shareUrl = `${window.location.origin}${PATH.customer.searchMoverDetail(moverId)}`;
+  const shareUrl = `${process.env.NEXT_PUBLIC_BASE_URL}${PATH.customer.searchMoverDetail(moverId)}`;
   const toastMsg = '확정하지 않은 견적이에요!';
   const isPending = !data.offers[0].isCompleted; // isCompleted가 false인 경우 : 대기중인 견적
   const isConfirmed = data.offers[0].isConfirmedMover; // 확정견적

--- a/src/app/customer/search-mover/[moverId]/page.tsx
+++ b/src/app/customer/search-mover/[moverId]/page.tsx
@@ -5,7 +5,6 @@ import { MoverInfoFeature } from './features/MoverInfo/feature';
 import { ClientInteractions } from './components/ClientInteractions';
 import { notFound } from 'next/navigation';
 import { PATH } from '@/shared/constants';
-import { headers } from 'next/headers';
 
 interface PageProps {
   params: Promise<{
@@ -48,9 +47,6 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function Page({ params }: PageProps) {
   const { moverId } = await params;
-  const header = await headers();
-  const host = header.get('host');
-  const protocol = process.env.NODE_ENV === 'development' ? 'http' : 'https';
 
   try {
     // 서버에서 기사님 정보만 페치
@@ -60,7 +56,8 @@ export default async function Page({ params }: PageProps) {
       notFound();
     }
 
-    const shareUrl = `${protocol}://${host}${PATH.customer.searchMoverDetail(moverId)}`;
+    const shareUrl = `${process.env.NEXT_PUBLIC_BASE_URL}${PATH.customer.searchMoverDetail(moverId)}`;
+    console.log('shareUrl: ', shareUrl);
     const shareLinkTitle = '나만 알기엔 아쉬운 기사님인가요?';
     const moverInfo = moverResponse.data;
 


### PR DESCRIPTION
## 🌟 작업 내용 요약(500자 이내)
- 일반유저 기사님 상세, 견적 상세에서 공유 기능에 사용되는 shareUrl 수정
- 기존에 window나 next/headers에서 가져와서 설정.
- 배포환경에서 404페이지로 이동해서, 아예 url 호스트 부분을 환경변수로 넣는걸로 변경함
