### PR TITLE
test: oauth 로그인 이후 refresh 함수로 쿠키 저장 테스트

### DIFF
--- a/src/app/(auth)/oauth/callback/_components/OAuthCallbackIndex.tsx
+++ b/src/app/(auth)/oauth/callback/_components/OAuthCallbackIndex.tsx
@@ -11,6 +11,7 @@ import useUserStore from '@/shared/store/useUserStore';
 import { PATH } from '@/shared/constants';
 import { OAuthProfile } from '@/shared/core/Auth/service';
 import { GetCustomerProfileData, GetMoverProfileData } from '@/shared/types/types';
+import customAxios from '@/lib/customAxios';
 
 const blink = keyframes`
   0%   { opacity: 0; }
@@ -34,8 +35,15 @@ export default function OAuthCallbackIndex() {
       return;
     }
 
+    const refresh = async () => {
+      await customAxios.post('/api/auth/refresh', {
+        refreshToken,
+      });
+    };
+
     const OAuthLogin = async () => {
       try {
+        await refresh();
         localStorage.setItem('accessToken', accessToken);
         if (process.env.NODE_ENV === 'development') {
           localStorage.setItem('refreshToken', refreshToken);


### PR DESCRIPTION
## 🌟 작업 내용 요약(500자 이내)
- 이번 PR의 목적과 주요 변경사항을 간단히 작성해주세요.
oauth 로그인 이후 refresh 함수로 쿠키 저장 테스트
  
## 📢 팀원들에게 공유 사항
- 아직 로컬 환경에서 dev 백엔드 API 연결이 안되어서 dev 브랜치에서 테스트는 못했습니다. (다만 oauth 로그인 이후 쿠키 저장은 확인, 그 뒤에 다른 api 요청은 모두 internal Server Error)
- oauth로그인 이후 refreshToken을 body로 보내서  refresh 되는 순간 쿠키에 저장되도록 쿠키 저장 방식을 우회 시도했습니다.

