### PR TITLE
[FIX] : 중복4자이상, 영문까지 포함, 02 전화번호9자 10자 포함, 로그아웃 에세스 토큰 삭제

### DIFF
--- a/src/shared/components/Form/Auth/AuthForm.tsx
+++ b/src/shared/components/Form/Auth/AuthForm.tsx
@@ -2,7 +2,7 @@
 
 import InputField from '@/shared/components/Input/InputField';
 import { Stack } from '@mui/material';
-import { useForm, FormProvider } from 'react-hook-form';
+import { useForm, FormProvider, useWatch } from 'react-hook-form';
 import { SolidButton } from '../../Button/SolidButton';
 import useUserStore from '@/shared/store/useUserStore';
 import { useRouter } from 'next/navigation';
@@ -18,6 +18,7 @@ import { CustomerLoginData, LoginPayload, MoverLoginData, SignupPayload } from '
 import { invalidateQueryKeys } from '@/shared/utils/invalidateQueryKeys';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSearchMoverStore } from '@/app/customer/search-mover/core/hooks/useSearchMoverStore';
+import { useEffect } from 'react';
 
 interface AuthFormProps {
   mode: 'login' | 'signup';
@@ -33,12 +34,19 @@ export default function AuthForm({ mode, userType }: AuthFormProps) {
   });
   const {
     watch,
+    control,
     handleSubmit,
+    trigger,
     formState: { isSubmitting },
   } = methods;
   const router = useRouter();
   const { setUserInfo, setCustomerData, setMoverData } = useUserStore();
   const { reset: resetSearchMoverStore } = useSearchMoverStore();
+
+  const password = useWatch({ control, name: 'password', defaultValue: '' });
+  useEffect(() => {
+    trigger('passwordConfirm');
+  }, [password, trigger]);
 
   const isMd = useMediaQuery(theme.breakpoints.down('md'));
   const isLogin = mode === 'login';

--- a/src/shared/store/useUserStore.ts
+++ b/src/shared/store/useUserStore.ts
@@ -66,8 +66,8 @@ const useUserStore = create<UserStore>()(
         set({ moverData });
       },
       logout: () => {
+        localStorage.removeItem('accessToken');
         if (process.env.NODE_ENV === 'development') {
-          localStorage.removeItem('accessToken');
           localStorage.removeItem('refreshToken');
         }
         set({ userType: 'temp', userInfo: null, customerData: null, moverData: null, isAuthenticated: false });


### PR DESCRIPTION
## 🌟 작업 내용 요약(500자 이내)
- 02 전화번호 총 9자 와 10자 두 가지 상황다 포함했습니다.
- 로그아웃시 에세스 토큰 삭제 로직 추가했습니다.
- 비밀번호 조건을 변경했습니다.   

  
## 📢 팀원들에게 공유 사항
- 비밀 번호 조건
 a. 영문, 숫자, 특수 문자 포함
 b. 같은 문자 3자 초과시 오류
 c. 비밀번호와 확인 조건만족 후 비밀번호 변경시 비밀번호 확인이 바로 체크하게 변경 


## 📷 스크린샷
- 전화번호 02 9자리 체크

