### PR TITLE
[FIX] : 에러 메세지 Thrrow처리, AuthForm + ProfileForm수정

### DIFF
--- a/src/lib/customAxios.ts
+++ b/src/lib/customAxios.ts
@@ -1,4 +1,10 @@
-import axios, { AxiosAdapter, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import axios, {
+  AxiosAdapter,
+  AxiosInstance,
+  AxiosRequestConfig,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+} from 'axios';
 
 // url 타입 보강
 type URLQueryParams = Record<string, string | number | boolean>;
@@ -91,6 +97,12 @@ const fetchAdapter: AxiosAdapter = async (config: AxiosRequestConfig): Promise<A
     };
     // config 정보도 직접 추가
     (error as any).config = internalConfig;
+
+    // error.message를 넘겨 alert를 띄우기 위해 넘김
+    if (typeof responseData === 'object' && responseData !== null && 'message' in responseData) {
+      error.message = responseData.message;
+    }
+
     throw error;
   }
 
@@ -126,7 +138,7 @@ const requestInterceptor = (axiosInstance: AxiosInstance) => {
     },
     function (error) {
       return Promise.reject(error);
-    }
+    },
   );
 
   return axiosInstance;
@@ -182,11 +194,15 @@ const responseInterceptor = (axiosInstance: AxiosInstance) => {
               return Promise.reject(error);
             }
 
-            res = await axiosInstance.post('/api/auth/refresh', {}, {
-              headers: {
-                Authorization: `refresh-token ${refreshToken}`
+            res = await axiosInstance.post(
+              '/api/auth/refresh',
+              {},
+              {
+                headers: {
+                  Authorization: `refresh-token ${refreshToken}`,
+                },
               },
-            });
+            );
           } else {
             // 배포 환경에서는 쿠키 기반으로 refresh
             res = await axiosInstance.post('/api/auth/refresh');
@@ -197,7 +213,7 @@ const responseInterceptor = (axiosInstance: AxiosInstance) => {
           }
           // 개발/배포 환경 모두에서 로컬스토리지 업데이트
           localStorage.setItem('accessToken', newAccessToken);
-          
+
           // axios 인스턴스의 기본 헤더 업데이트
           axiosInstance.defaults.headers['Authorization'] = `Bearer ${newAccessToken}`;
           onTokenRefreshed(newAccessToken);
@@ -217,7 +233,7 @@ const responseInterceptor = (axiosInstance: AxiosInstance) => {
         typeof data === 'string' ? data : typeof data?.message === 'string' ? data.message : '요청에 실패했습니다.';
 
       return Promise.reject(new Error(message));
-    }
+    },
   );
   return axiosInstance;
 };

--- a/src/shared/components/Form/Auth/AuthForm.tsx
+++ b/src/shared/components/Form/Auth/AuthForm.tsx
@@ -86,7 +86,7 @@ export default function AuthForm({ mode, userType }: AuthFormProps) {
         }
 
         if (userType === 'customer') {
-          const customer = (res?.data as CustomerLoginData).customer;
+          const { accessToken, refreshToken, customer } = res.data as CustomerLoginData;
 
           if (!customer) {
             alert('고객 로그인 정보가 존재하지 않습니다.');
@@ -111,9 +111,9 @@ export default function AuthForm({ mode, userType }: AuthFormProps) {
           resetSearchMoverStore();
 
           //development 일때만 로컬에 저장
-          localStorage.setItem('accessToken', res.data.accessToken);
+          localStorage.setItem('accessToken', accessToken);
           if (process.env.NODE_ENV === 'development') {
-            localStorage.setItem('refreshToken', res.data.refreshToken);
+            localStorage.setItem('refreshToken', refreshToken);
           }
 
           if (!customer.isProfile) {
@@ -127,7 +127,7 @@ export default function AuthForm({ mode, userType }: AuthFormProps) {
           }
         }
         if (userType === 'mover') {
-          const mover = (res?.data as MoverLoginData).mover;
+          const { accessToken, refreshToken, mover } = res.data as MoverLoginData;
 
           if (!mover) {
             alert('기사 로그인 정보가 존재하지 않습니다.');
@@ -160,9 +160,9 @@ export default function AuthForm({ mode, userType }: AuthFormProps) {
           resetSearchMoverStore();
 
           //development 일때만 로컬에 저장
-          localStorage.setItem('accessToken', res.data.accessToken);
+          localStorage.setItem('accessToken', accessToken);
           if (process.env.NODE_ENV === 'development') {
-            localStorage.setItem('refreshToken', res.data.refreshToken);
+            localStorage.setItem('refreshToken', refreshToken);
           }
 
           if (!mover.isProfile) {
@@ -191,10 +191,18 @@ export default function AuthForm({ mode, userType }: AuthFormProps) {
         return router.push(redirectPath);
       }
     } catch (err) {
-      const message =
-        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ??
-        (err as Error)?.message ??
-        '처리 중 오류가 발생했습니다.';
+      const customError = err as {
+        response?: {
+          data?: {
+            message?: string;
+            errorCode?: string;
+          };
+          status?: number;
+        };
+        message?: string;
+      };
+
+      const message = customError.response?.data?.message || customError.message || '처리 중 오류가 발생했습니다.';
       alert(message);
       return;
     }

--- a/src/shared/components/Form/Profile/ProfileForm.tsx
+++ b/src/shared/components/Form/Profile/ProfileForm.tsx
@@ -304,8 +304,8 @@ export default function ProfileForm({ mode, userType }: ProfileFormProps) {
         const regionKeys = (d.region ?? []).map(getRegionKey).filter(Boolean);
 
         if (d.username) formData.append('username', d.username);
-        if (d.currPassword && d.newPassword) {
-          formData.append('currPassword', d.currPassword);
+        if (d.currentPassword && d.newPassword) {
+          formData.append('currPassword', d.currentPassword);
           formData.append('newPassword', d.newPassword);
         }
         if (d.profileImage && d.profileImage instanceof File) {

--- a/src/shared/types/types.ts
+++ b/src/shared/types/types.ts
@@ -144,7 +144,7 @@ export interface FormUIFields {
 export interface CustomerProfileForm extends FormUIFields {
   profileImage?: File;
   username?: string;
-  currPassword?: string;
+  currentPassword?: string;
   newPassword?: string;
   phoneNumber: string;
   wantService: string[];


### PR DESCRIPTION
## 🌟 작업 내용 요약(500자 이내)
- 로그인 API오류시 오류 리스폰 메세지 추출하여 뜨도록 수정
- 프로필 수정 유저시 비밀번호 바뀌지 않는 오류 수정
  
## 📢 팀원들에게 공유 사항
- 카카오톡 공유는 리다이렉트와 허가 웹 추가로 해결 됐습니다

