### PR TITLE
[FIX] : 기사 받은 요청, 보낸 견적 조회, 반려 요청 조회 수정

### DIFF
--- a/src/app/mover/moving-quote/history/[quoteId]/core/components/QuotationDetail.tsx
+++ b/src/app/mover/moving-quote/history/[quoteId]/core/components/QuotationDetail.tsx
@@ -80,7 +80,7 @@ export default function QuotationDetail({ quoteId }: QuotationDetailProps) {
       gap="117px"
     >
       <Stack width="100%" direction="column" gap={isDesktop ? '40px' : '24px'}>
-        <Card type="moveQuotation" data={cardData} />
+        <Card type="confirmRequest" data={cardData} />
 
         {!isDesktop && (
           <>

--- a/src/app/mover/moving-quote/history/core/components/QuoteOffer.tsx
+++ b/src/app/mover/moving-quote/history/core/components/QuoteOffer.tsx
@@ -8,13 +8,15 @@ import Image from 'next/image';
 import { Typo } from '@/shared/styles/Typo/Typo';
 import { colorChips } from '@/shared/styles/colorChips';
 
-export default function QuoteOffer() {
+export default function QuoteOffer({ tabType }: { tabType: string }) {
   const isMd = useMediaQuery(theme.breakpoints.down('md'));
   const bottomRef = useRef<HTMLDivElement | null>(null);
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } = useInfiniteSentQuotations();
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending, refetch } =
+    useInfiniteSentQuotations(tabType);
 
   const list = data?.pages.flatMap((page) => page.list) ?? [];
+
   const cards = list.map(mapSentQuotationToCardData);
 
   const isJustifyContent = isPending || isFetchingNextPage || list.length === 0;
@@ -35,6 +37,10 @@ export default function QuoteOffer() {
     return () => observer.disconnect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bottomRef.current, hasNextPage]);
+
+  useEffect(() => {
+    refetch();
+  }, [tabType, refetch]);
 
   return (
     <Grid container spacing={2} width="100%" justifyContent={isJustifyContent ? 'center' : ''}>

--- a/src/app/mover/moving-quote/history/core/components/RejectedQuot.tsx
+++ b/src/app/mover/moving-quote/history/core/components/RejectedQuot.tsx
@@ -9,13 +9,15 @@ import { Typo } from '@/shared/styles/Typo/Typo';
 import Image from 'next/image';
 import { colorChips } from '@/shared/styles/colorChips';
 
-export default function RejectedQuot() {
+export default function RejectedQuot({ tabType }: { tabType: string }) {
   const isMd = useMediaQuery(theme.breakpoints.down('md'));
   const bottomRef = useRef<HTMLDivElement | null>(null);
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } = useInfiniteRejectedQuotations();
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending, refetch } =
+    useInfiniteRejectedQuotations(tabType);
 
   const list = data?.pages.flatMap((page) => page.list) ?? [];
+  console.log('RejectedQuotlist', list);
   const cards = list.map(mapRejectedQuotationToCardData);
 
   const isJustifyContent = isPending || isFetchingNextPage || list.length === 0;
@@ -36,6 +38,10 @@ export default function RejectedQuot() {
     return () => observer.disconnect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bottomRef.current, hasNextPage]);
+
+  useEffect(() => {
+    refetch();
+  }, [tabType, refetch]);
 
   return (
     <Grid container spacing={2} width="100%" justifyContent={isJustifyContent ? 'center' : ''}>

--- a/src/app/mover/moving-quote/history/page.tsx
+++ b/src/app/mover/moving-quote/history/page.tsx
@@ -18,8 +18,8 @@ export default function MoverMovingQuoteHistoryPage() {
         alignItems="flex-start"
         bgcolor={colorChips.background.f7f7f7}
       ></Stack>
-      {tabBarType === 'quoteOffer' && <QuoteOffer />}
-      {tabBarType === 'rejectedQuote' && <RejectedQuot />}
+      {tabBarType === 'quoteOffer' && <QuoteOffer tabType="quoteOffer" />}
+      {tabBarType === 'rejectedQuote' && <RejectedQuot tabType="rejectedQuote" />}
     </Stack>
   );
 }

--- a/src/app/mover/moving-quote/request/core/components/RequestIndex.tsx
+++ b/src/app/mover/moving-quote/request/core/components/RequestIndex.tsx
@@ -75,9 +75,13 @@ export default function RequestIndex() {
   const CheckboxFilterType = [
     {
       label: '서비스 가능 지역',
-      count:
-        (statsData?.startRegionStats?.[selectedRegion?.[0] ?? ''] ?? 0) +
-        (statsData?.endRegionStats?.[selectedRegion?.[0] ?? ''] ?? 0),
+      count: Array.isArray(selectedRegion)
+        ? selectedRegion.reduce(
+            (acc, region) =>
+              acc + (statsData?.startRegionStats?.[region] ?? 0) + (statsData?.endRegionStats?.[region] ?? 0),
+            0,
+          )
+        : 0,
       checked: selected['서비스 가능 지역'],
     },
     { label: '지정 견적 요청', count: statsData?.assignedQuotationCount ?? 0, checked: selected['지정 견적 요청'] },

--- a/src/app/mover/moving-quote/request/core/components/RequestModal.tsx
+++ b/src/app/mover/moving-quote/request/core/components/RequestModal.tsx
@@ -51,7 +51,6 @@ export default function RequestModal({ mode, requestCardData, onClose, onSuccess
         const payload = {
           price: Number(data.quoteAmount),
           comment: data.comment ?? '',
-
           customerId: requestCardData.customerId as string,
           quotationId: requestCardData.id as string,
           isAssignQuo: !!requestCardData.isAssignQuo,

--- a/src/app/mover/moving-quote/request/core/hook/mapToUserCardData.ts
+++ b/src/app/mover/moving-quote/request/core/hook/mapToUserCardData.ts
@@ -49,6 +49,7 @@ export function mapToUserCardData(apiData: QuotationAPIData): UserCardData {
     endPoint: cutAddress(apiData.endAddress),
     service: [moveTypeToLabel(apiData.moveType)],
     isAssigned: apiData.isAssigned,
+    isAssignQuo: apiData.isAssigned,
     status: isValidStatus(apiData.status) ? apiData.status : undefined,
   };
 }

--- a/src/app/mover/moving-quote/request/core/hook/requestHooks.ts
+++ b/src/app/mover/moving-quote/request/core/hook/requestHooks.ts
@@ -14,7 +14,7 @@ export const useMoverQuotations = (params: GetMoverQuotationsParams) =>
     queryFn: ({ pageParam }) => getMoverQuotations({ ...params, ...pageParam }),
     initialPageParam: undefined,
     getNextPageParam: (last) => last.nextCursor ?? undefined,
-    staleTime: 1000 * 60 * 3,
+    staleTime: 0,
     refetchOnWindowFocus: false,
   });
 
@@ -22,6 +22,6 @@ export function useMoverQuotationStats(params: Omit<GetMoverQuotationsParams, 'c
   return useQuery({
     queryKey: ['moverQuotationStats', params],
     queryFn: () => getMoverQuotationStats(params),
-    staleTime: 1000 * 60 * 5,
+    staleTime: 0,
   });
 }

--- a/src/app/mover/my-page/_core/hook/myPageHooks.ts
+++ b/src/app/mover/my-page/_core/hook/myPageHooks.ts
@@ -51,8 +51,20 @@ export function mapMoverProfileToCardData(moverData: MoverData, userInfo: UserIn
   };
 }
 export function mapReviewToCardData(review: MoverReviewListItem): UserCardData {
+  const nickname = review.customerNick.split(' ')[0];
+
+  const getMaskedNickname = (name: string) => {
+    if (name.length <= 3) {
+      return name[0] + '*'.repeat(name.length - 1);
+    } else {
+      return name.slice(0, 3) + '*'.repeat(name.length - 3);
+    }
+  };
+
+  const formattedNickname = getMaskedNickname(nickname);
+
   return {
-    name: review.customerNick,
+    name: formattedNickname,
     review: {
       content: review.content,
       averageScore: review.rating,

--- a/src/shared/components/Card/Card.tsx
+++ b/src/shared/components/Card/Card.tsx
@@ -28,6 +28,7 @@ export default function Card({ type, data, isModal, height, bgColor, onRequestCl
   const isProfile = type === 'profile';
   const isReview = type === 'review';
   const isFinish = type === 'rejectRequest' || type === 'finishRequest' || type === 'refuse';
+  const isFinishExcludeReject = type === 'finishRequest' || type === 'refuse';
 
   return (
     <Box position="relative" width="100%">
@@ -56,7 +57,7 @@ export default function Card({ type, data, isModal, height, bgColor, onRequestCl
                 : '이사 완료된 견적이에요'}
             </Typo>
 
-            {isFinish && (
+            {isFinishExcludeReject && (
               <OutlinedButton
                 text="견적 상세보기"
                 width="100%"

--- a/src/shared/components/Card/CardHeader.tsx
+++ b/src/shared/components/Card/CardHeader.tsx
@@ -24,6 +24,9 @@ const labelToCategoryKey: Record<string, CategoryKey> = {
   '지정 견적 요청': 'select',
   '견적 대기': 'wait',
   '확정 견적': 'confirmed',
+  '확정 대기': 'confirmedWait',
+  '이사 완료': 'done',
+  '거절된 견적': 'refuse',
 };
 
 export default function CardHeader({ type, data, isModal }: CardHeaderProps) {
@@ -53,6 +56,7 @@ export default function CardHeader({ type, data, isModal }: CardHeaderProps) {
     type !== 'finishReview';
 
   const services: string[] = Array.isArray(data.service) ? data.service : [];
+
   const name: string = data.name || data.name || '';
   const detailDescription: string = data.detailDescription || '';
 
@@ -68,7 +72,10 @@ export default function CardHeader({ type, data, isModal }: CardHeaderProps) {
           <Stack direction="row" justifyContent="space-between" alignItems="center" width="100%">
             <Stack direction="row" flexWrap="wrap" sx={{ gap: { xs: '8px', md: '12px' }, flex: 1, minWidth: 0 }}>
               {data.status?.toUpperCase() === 'PENDING' && <Chip type="wait" />}
-              {data.status?.toUpperCase() === 'CONFIRMED' && <Chip type="confirmed" />}
+              {data.status?.toUpperCase() === 'CONFIRMED' &&
+                (data.isAssigned || data.isConfirmedToMe ? <Chip type="confirmed" /> : <Chip type="confirmedWait" />)}
+              {data.status?.toUpperCase() === 'COMPLETED' && <Chip type="done" />}
+              {data.status?.toUpperCase() === 'REFUSED' && <Chip type="refuse" />}
 
               {services.map((label, idx) => {
                 const category = labelToCategoryKey[label];

--- a/src/shared/components/Card/CardPresets.ts
+++ b/src/shared/components/Card/CardPresets.ts
@@ -16,6 +16,8 @@ export type PresetCardName =
   | 'review' // 리뷰 카드
   | 'refuse'; //유저에 의해 거절
 
+type QuotationDisplayStatus = QuotationStatus | 'REFUSED';
+
 export interface UserCardData {
   id?: string;
   name?: string;
@@ -42,11 +44,12 @@ export interface UserCardData {
   quoteAmount?: number;
   reviewContent?: string;
   createTime?: string;
-  status?: QuotationStatus;
+  status?: QuotationDisplayStatus;
   isAssigned?: boolean;
   isAssignQuo?: boolean;
   reviewCounts?: number;
   totalRating?: number;
+  isConfirmedToMe?: boolean;
   confirmedCounts?: number;
 }
 

--- a/src/shared/components/Card/RequestCardInfo.tsx
+++ b/src/shared/components/Card/RequestCardInfo.tsx
@@ -22,7 +22,7 @@ export default function RequestConfirmCardInfo({ type, data, onClickRequest, onC
   const isMdDown = useMediaQuery(theme.breakpoints.down('md'));
   const isMd = useMediaQuery(theme.breakpoints.up('md'));
   const showButtons = type === 'request';
-  const isConfirmRequest = type === 'confirmRequest';
+  const isConfirmRequest = type === 'confirmRequest' || type === 'rejectRequest';
   const isAssigned = !!data.isAssigned;
   const formatted = (date: string): string => {
     return dayjs(date).format('YYYY.MM.DD(dd)');
@@ -150,7 +150,7 @@ export default function RequestConfirmCardInfo({ type, data, onClickRequest, onC
       );
     }
 
-    if (isMd) {
+    if (isMd || isConfirmRequest) {
       return (
         <>
           <Divider />
@@ -301,10 +301,10 @@ export default function RequestConfirmCardInfo({ type, data, onClickRequest, onC
       borderRadius={isMdDown ? '16px' : '24px'}
     >
       <Stack direction={isSm ? 'column' : 'row'} justifyContent="space-between" alignItems="flex-start">
-        {!isModal && <Typo className={isMdDown ? 'text_SB_16' : 'text_SB_20'}>{`${data.name} 고객님`}</Typo>}
+        {!isModal && <Typo className={isSm ? 'text_SB_16' : 'text_SB_20'}>{`${data.name} 고객님`}</Typo>}
 
         {isSm && !isModal && (
-          <Stack direction="row" alignItems="center" sx={{ textWrap: 'nowrap' }} gap="8px">
+          <Stack direction="row" alignItems="center" sx={{ textWrap: 'nowrap' }} gap="8px" paddingTop="16px">
             <Typo
               className="text_M_14"
               style={{

--- a/src/shared/components/Chip/Chip.tsx
+++ b/src/shared/components/Chip/Chip.tsx
@@ -107,6 +107,23 @@ export const Category = {
       md: '34px',
     },
   },
+  confirmedWait: {
+    type: '확정 대기',
+    radius: '4px',
+    color: colorChips.primary[400],
+    bgColor: colorChips.line['f2f3f8'],
+    className: 'text_SB_16',
+    mobileClassName: 'text_SB_13',
+    shadow: '4px 4px 8px rgba(217, 217, 217, 0.1)',
+    padding: {
+      xs: '2px 6px',
+      md: '4px 6px',
+    },
+    height: {
+      xs: '26px',
+      md: '34px',
+    },
+  },
   confirmed: {
     type: '확정 견적',
     radius: '4px',
@@ -174,6 +191,40 @@ export const Category = {
     height: {
       sm: '24px',
       md: '28px',
+    },
+  },
+  done: {
+    type: '이사 완료',
+    radius: '4px',
+    color: colorChips.primary[400],
+    bgColor: colorChips.line['f2f3f8'],
+    className: 'text_SB_16',
+    mobileClassName: 'text_SB_13',
+    shadow: '4px 4px 8px rgba(217, 217, 217, 0.1)',
+    padding: {
+      xs: '2px 6px',
+      md: '4px 6px',
+    },
+    height: {
+      xs: '26px',
+      md: '34px',
+    },
+  },
+  refuse: {
+    type: '거절된 견적',
+    radius: '4px',
+    color: colorChips.primary[400],
+    bgColor: colorChips.line['f2f3f8'],
+    className: 'text_SB_16',
+    mobileClassName: 'text_SB_13',
+    shadow: '4px 4px 8px rgba(217, 217, 217, 0.1)',
+    padding: {
+      xs: '2px 6px',
+      md: '4px 6px',
+    },
+    height: {
+      xs: '26px',
+      md: '34px',
     },
   },
 } as const;


### PR DESCRIPTION
## 🌟 작업 내용 요약(500자 이내)
- 조회 staleTime : 0 으로 변경(항상 새 데이터가 필요하다 판단하여 변경함)
- 서비스 가능 지역 합으로 변경(중복 제거 필요)
- 견적 보낼시 isAssignQuo가 들어가게 변경
- 카드 헤더 칩 추가(확정 대기, 이사완료, 거절된 견적), 추가에 따른 맵핑 로직 수정
- 견적 금액이 필요 없는 곳 로직 추가로 제거 완료
  
## 📢 팀원들에게 공유 사항
- 개발 환경에서 확인 했으나 배포 환경에서 한번 더 확인해야함 (개발환경은 예전 데이터랑 섞여서 status값이 다름)
