### PR TITLE
[FIX] : 에러 및 404 페이지 퍼블릭 처리 및 토큰이 없을떄 api요청시 status 401 처리

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -38,6 +38,10 @@ export default function middleware(req: NextRequest) {
   console.log(' pathname', pathname);
   console.log(' token', token);
 
+  if (pathname === '/api/auth/login' || pathname === '/api/auth/signup') {
+    return NextResponse.next();
+  }
+
   if (isPublic(pathname)) {
     if (AUTH_PAGES.includes(pathname) && token) {
       try {


### PR DESCRIPTION
## 🌟 작업 내용 요약(500자 이내)
- 퍼블릭 주소에 에러 및 404 페이지 추가
- api 요청중 에세스 토큰이 없을 시 401 status 리턴하도록 수정
