### PR TITLE
[FIX] : 남은 콘솔로그 제거, SessionCheck 레이아웃에 추가, customAixos 로그인 회원가입 api일시 401에러 전에 통과

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { QueryProvider } from '@/shared/context/QueryProvider';
 import KakaoScriptLoader from '@/shared/context/KakaoScriptLoader';
 import FaceHydration from './_core/_components/FaceHydration';
 import AlertListener from './_core/_components/AlertListener';
+import SessionCheck from './_core/_components/SessionCheck';
 
 export const metadata: Metadata = {
   title: 'Moving',
@@ -46,6 +47,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           <ThemeProvider theme={theme}>
             <CssBaseline />
             <FaceHydration />
+            <SessionCheck />
             <Suspense fallback={null}>
               <AlertListener />
             </Suspense>

--- a/src/app/mover/moving-quote/history/core/components/RejectedQuot.tsx
+++ b/src/app/mover/moving-quote/history/core/components/RejectedQuot.tsx
@@ -17,7 +17,7 @@ export default function RejectedQuot({ tabType }: { tabType: string }) {
     useInfiniteRejectedQuotations(tabType);
 
   const list = data?.pages.flatMap((page) => page.list) ?? [];
-  console.log('RejectedQuotlist', list);
+
   const cards = list.map(mapRejectedQuotationToCardData);
 
   const isJustifyContent = isPending || isFetchingNextPage || list.length === 0;

--- a/src/lib/customAxios.ts
+++ b/src/lib/customAxios.ts
@@ -171,6 +171,15 @@ const responseInterceptor = (axiosInstance: AxiosInstance) => {
     async function (error) {
       const status = error.response?.status;
       const originalRequest = error.config || error.response?.config;
+      const isAuthApi =
+        originalRequest?.url?.endsWith('/api/auth/mover/login') ||
+        originalRequest?.url?.endsWith('/api/auth/customer/login') ||
+        originalRequest?.url?.endsWith('/api/auth/customer/login') ||
+        originalRequest?.url?.endsWith('/api/auth/mover/signup');
+
+      if (isAuthApi) {
+        return Promise.reject(error);
+      }
 
       if (status === 401 && !originalRequest._retry) {
         if (isRefreshing) {


### PR DESCRIPTION
## 🌟 작업 내용 요약(500자 이내)
- 남은 콘솔 체크 후 제거 했습니다
- SessionCheck 루트 레이아웃에 빠져있어서 추가했습니다
- customAixos 로직 중 로그인, 회원가입은 401에러 전에 통과 시키도록 로직 추가했습니다.