### PR TITLE
[FIX] : 카드헤더 칩 부분 및 기사 보낸 견적 조회 데이터 맵핑 조건 수정

### DIFF
--- a/src/app/mover/moving-quote/history/core/hook/historyHooks.ts
+++ b/src/app/mover/moving-quote/history/core/hook/historyHooks.ts
@@ -58,14 +58,13 @@ export function mapSentQuotationToCardData(apiData: SentQuotationAPIData): {
   const isConfirmedQuotation =
     (apiData.isConfirmedToMe === true && apiData.status === 'CONFIRMED') ||
     (apiData.isConfirmedToMe === true && apiData.status === 'COMPLETED');
-  const isConfirmPending = apiData.isConfirmedToMe === false && apiData.status === 'CONFIRMED';
 
   if (isFinishRequest) {
     //  이사 완료
     cardType = 'finishRequest';
     displayStatus = 'COMPLETED';
-  } else if (isConfirmedQuotation || isConfirmPending) {
-    // 확정 견적 / 확정 대기
+  } else if (isConfirmedQuotation) {
+    // 확정 견적
     cardType = 'moveQuotation';
     displayStatus = 'CONFIRMED';
   } else if (isRefuse) {

--- a/src/shared/components/Card/CardHeader.tsx
+++ b/src/shared/components/Card/CardHeader.tsx
@@ -71,9 +71,9 @@ export default function CardHeader({ type, data, isModal }: CardHeaderProps) {
         {(services.length > 0 || detailDescription) && type !== 'profile' && type !== 'review' ? (
           <Stack direction="row" justifyContent="space-between" alignItems="center" width="100%">
             <Stack direction="row" flexWrap="wrap" sx={{ gap: { xs: '8px', md: '12px' }, flex: 1, minWidth: 0 }}>
-              {data.status?.toUpperCase() === 'PENDING' && <Chip type="wait" />}
-              {data.status?.toUpperCase() === 'CONFIRMED' &&
-                (data.isAssigned || data.isConfirmedToMe ? <Chip type="confirmed" /> : <Chip type="confirmedWait" />)}
+              {data.status?.toUpperCase() === 'PENDING' &&
+                (data.isConfirmedToMe != null ? <Chip type="confirmedWait" /> : <Chip type="wait" />)}
+              {data.status?.toUpperCase() === 'CONFIRMED' && data.isConfirmedToMe && <Chip type="confirmed" />}
               {data.status?.toUpperCase() === 'COMPLETED' && <Chip type="done" />}
               {data.status?.toUpperCase() === 'REFUSED' && <Chip type="refuse" />}
 


### PR DESCRIPTION
## 🌟 작업 내용 요약(500자 이내)
- 카드헤더 칩 부분 및 기사 보낸 견적 조회 데이터 맵핑 조건 수정

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/00759e19-5c39-4254-ad3d-aa4823eeb97b)
